### PR TITLE
Specified minimum JDK version to 1.8

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -26,7 +26,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon).
 === Basic Compile and Test
 
 To build the source you will need to install
-http://maven.apache.org/run-maven/index.html[Apache Maven] v3.0.6 or above and JDK 1.7.
+http://maven.apache.org/run-maven/index.html[Apache Maven] v3.0.6 or above and JDK 1.8.
 
 Spring Cloud uses Maven for most build-related activities, and you
 should be able to get off the ground quite quickly by cloning the


### PR DESCRIPTION
The spring-cloud-netflix-turbine-amqp module requires JDK 1.8
